### PR TITLE
useContext側で初期値を設定して、そのcontextオブジェクトを一覧と詳細表示両方で参照できるロジック

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 import { AlbumProvider } from './providers/AlbumProvider'
+import { PhotoProvider } from './providers/PhotoProvider'
 import { Albums } from './pages/Albums'
 import { AlbumDetail } from './pages/AlbumDetail'
+import { Photos } from './pages/Photos'
+import { PhotoDetail } from './pages/PhotoDetail'
 import { Box, Container } from '@material-ui/core'
 
 const App: React.VFC = () => {
@@ -19,6 +22,18 @@ const App: React.VFC = () => {
                 <AlbumDetail />
               </Route>
             </AlbumProvider>
+          </Switch>
+        </Router>
+        <Router>
+          <Switch>
+            <PhotoProvider>
+              <Route exact path="/photos">
+                <Photos />
+              </Route>
+              <Route path="/photos/:id">
+                <PhotoDetail />
+              </Route>
+            </PhotoProvider>
           </Switch>
         </Router>
       </Box>

--- a/src/domains/photos/models/index.ts
+++ b/src/domains/photos/models/index.ts
@@ -5,3 +5,19 @@ export type Photo = {
   url: string
   thumbnailUrl: string
 }
+
+export type PhotoState = {
+  photos: Photo[]
+  currentPhoto: Photo
+}
+
+export const initialPhotoState = {
+  photos: [],
+  currentPhoto: {
+    id: '',
+    albumId: '',
+    title: '',
+    url: '',
+    thumbnailUrl: '',
+  },
+}

--- a/src/domains/photos/services/index.ts
+++ b/src/domains/photos/services/index.ts
@@ -8,3 +8,12 @@ export const fetchPhotos = async (albumId: string): Promise<Photo[]> => {
   const items = response.json()
   return items
 }
+
+export const fetchPhoto = async (photoId: string): Promise<Photo> => {
+  const url = `https://jsonplaceholder.typicode.com/photos/${photoId}`
+  const response = await fetch(url, {
+    method: 'GET',
+  })
+  const item = response.json()
+  return item
+}

--- a/src/pages/PhotoDetail/index.tsx
+++ b/src/pages/PhotoDetail/index.tsx
@@ -1,9 +1,60 @@
-import React from 'react'
+import React, { useContext, useEffect } from 'react'
+import { Button, Box, Grid, Typography } from '@material-ui/core'
+import { useParams, useHistory } from 'react-router-dom'
+import { PhotoStateContext } from '../../providers/PhotoProvider'
 
 export const PhotoDetail: React.VFC = () => {
+  const [state, setState] = useContext(PhotoStateContext)
+  const { id } = useParams<{ id: string }>()
+  const handleClick = () => {
+    history.push('/photos')
+  }
+  const history = useHistory()
+
+  useEffect(() => {
+    async function fetchData() {
+      const photo = state.photos.find(
+        (photo) => Number(photo.id) === Number(id)
+      )
+      if (photo && photo.id !== '') {
+        // NOTE: PhotoのIDが変更されるタイミングでStateで一覧情報に関連する値は
+        // そのままで、詳細情報に関連のあるcurrentPhotoの値だけを変更したいので以下対応
+        setState({
+          ...state,
+          currentPhoto: photo,
+        })
+      }
+    }
+    fetchData()
+  }, [id, state])
+
+  // if (state.photos.length === 0) return <div>Loading...</div>
+
   return (
     <>
-      <h3>Photo Detail</h3>
+      <Box p={1}>
+        <Grid container>
+          <Grid item xs={12}>
+            <Typography component="h3" variant="h3">
+              {state.currentPhoto.title}
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            {state.currentPhoto.id}
+          </Grid>
+          <Grid item xs={12}>
+            <img
+              src={state.currentPhoto.thumbnailUrl}
+              alt={state.currentPhoto.title}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <Button variant="contained" color="primary" onClick={handleClick}>
+              一覧に戻る
+            </Button>
+          </Grid>
+        </Grid>
+      </Box>
     </>
   )
 }

--- a/src/pages/Photos/index.tsx
+++ b/src/pages/Photos/index.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import { PhotosTemplate } from '../../templates/PhotosTemplate'
+import { PhotoStateContext } from '../../providers/PhotoProvider'
 
 export const Photos: React.VFC = () => {
-  return <>Photos </>
+  const [state] = useContext(PhotoStateContext)
+
+  // NOTE: 一覧情報は非同期で取得されるため未取得状態で以下の対応が必要
+  if (state.photos.length === 0) return <div>Loading...</div>
+
+  return (
+    <>
+      <PhotosTemplate photos={state.photos} />
+    </>
+  )
 }

--- a/src/providers/PhotoProvider/index.tsx
+++ b/src/providers/PhotoProvider/index.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useState, useEffect } from 'react'
+import { PhotoState, initialPhotoState } from '../../domains/photos/models'
+import { fetchPhotos } from '../../domains/photos/services'
+
+export const PhotoStateContext = createContext<
+  [PhotoState, (state: PhotoState) => void]
+>([initialPhotoState, () => {}])
+
+export const PhotoProvider: React.FC = ({ children }) => {
+  const [state, setState] = useState<PhotoState>(initialPhotoState)
+
+  useEffect(() => {
+    async function fetchData() {
+      const initialAblumID = '1'
+      const items = await fetchPhotos(initialAblumID)
+      console.log(items)
+      // NOTE: JavaScriptのスプレッド構文を利用して初期値で何も設定してない一覧情報だけを設定
+      if (items.length > 0) {
+        setState({
+          ...state,
+          photos: items,
+        })
+      }
+    }
+    fetchData()
+  }, [])
+
+  return (
+    <>
+      <PhotoStateContext.Provider value={[state, setState]}>
+        <div>{children}</div>
+      </PhotoStateContext.Provider>
+    </>
+  )
+}

--- a/src/templates/PhotosTemplate/PhotoItem.tsx
+++ b/src/templates/PhotosTemplate/PhotoItem.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Button, Box, Grid, Typography } from '@material-ui/core'
+import { Photo } from '../../domains/photos/models'
+import { Link } from 'react-router-dom'
+
+type Props = {
+  photo: Photo
+}
+
+export const PhotoItem: React.VFC<Props> = ({ photo }) => {
+  return (
+    <>
+      <Box p={1}>
+        <Grid container>
+          <Grid item xs={9}>
+            <Typography component="h5" variant="h5">
+              {photo.title}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Link to={`/photos/${photo.id}`}>
+              <Button variant="contained" color="primary" data-id={photo.id}>
+                詳細情報確認
+              </Button>
+            </Link>
+          </Grid>
+        </Grid>
+      </Box>
+    </>
+  )
+}

--- a/src/templates/PhotosTemplate/index.tsx
+++ b/src/templates/PhotosTemplate/index.tsx
@@ -1,5 +1,22 @@
 import React from 'react'
+import { Typography } from '@material-ui/core'
+import { Photo } from '../../domains/photos/models'
+import { PhotoItem } from './PhotoItem'
 
-export const PhotosTemplate: React.VFC = () => {
-  return <>PhotosTemplate</>
+type Props = {
+  photos: Photo[]
+}
+
+export const PhotosTemplate: React.VFC<Props> = ({ photos }) => {
+  return (
+    <>
+      <Typography id="simple-modal-title" component="h3" variant="h3">
+        写真一覧
+      </Typography>
+
+      {photos.map((photo) => {
+        return <PhotoItem photo={photo} />
+      })}
+    </>
+  )
 }


### PR DESCRIPTION
## このPRについて

issue #1 対応

## 変更点

想定仕様
```
一覧画面、詳細画面どちらも直リンクでアクセスしても表示が適切に行える
```

これを踏まえ

1. useContext側で初期値となる値を設定
2. 一覧画面では取得済の一覧情報を表示
3. 詳細画面では、初期値は仮の情報がセットされてるため、useParams経由で取得したIDでfind→その値で、contextオブジェクトのstateを更新

というロジックを追加

![Jun-09-2021 16-15-37](https://user-images.githubusercontent.com/950924/121310242-1f95d300-c93e-11eb-9c3d-d4e64cc7dacc.gif)
